### PR TITLE
Security hardening: rate limiting, CSP, encoding, host validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,3 +113,5 @@ group :test do
 end
 
 gem "jsbundling-rails", "~> 1.3"
+
+gem "rack-attack", "~> 6.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -656,6 +658,7 @@ DEPENDENCIES
   propshaft
   pstore
   puma (>= 5.0)
+  rack-attack (~> 6.7)
   rails (~> 8.1.3)
   rails-controller-testing
   resend (~> 0.17)

--- a/app/middleware/encoding_error_handler.rb
+++ b/app/middleware/encoding_error_handler.rb
@@ -1,0 +1,11 @@
+class EncodingErrorHandler
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue Encoding::CompatibilityError, Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+    [400, { "content-type" => "text/plain" }, ["Bad Request"]]
+  end
+end

--- a/app/middleware/encoding_error_handler.rb
+++ b/app/middleware/encoding_error_handler.rb
@@ -6,6 +6,6 @@ class EncodingErrorHandler
   def call(env)
     @app.call(env)
   rescue Encoding::CompatibilityError, Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
-    [400, { "content-type" => "text/plain" }, ["Bad Request"]]
+    [ 400, { "content-type" => "text/plain" }, [ "Bad Request" ] ]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,10 @@ module ConduitApp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Catch malformed encoding in request parameters before they reach the app
+    require_relative "../app/middleware/encoding_error_handler"
+    config.middleware.insert_before 0, EncodingErrorHandler
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,11 +76,15 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  # Allows any *.crowwoods.com domain plus the production domain.
+  # Add additional community domains here as they are onboarded.
+  config.hosts = [
+    "conduit.crowwoods.com",
+    "conduit-staging.crowwoods.com",
+    /.*\.crowwoods\.com/,
+    IPAddr.new("0.0.0.0/0")       # Allow IP-based health checks from load balancer
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,10 +81,9 @@ Rails.application.configure do
   config.hosts = [
     "conduit.crowwoods.com",
     "conduit-staging.crowwoods.com",
-    /.*\.crowwoods\.com/,
-    IPAddr.new("0.0.0.0/0")       # Allow IP-based health checks from load balancer
+    /.*\.crowwoods\.com/
   ]
 
-  # Skip DNS rebinding protection for the default health check endpoint.
+  # Skip DNS rebinding protection for the health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,25 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data, "fonts.gstatic.com"
+    policy.img_src     :self, :https, :data, :blob
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https, :unsafe_inline, "fonts.googleapis.com"
+    policy.connect_src :self, :https, :wss
+    policy.frame_src   :none
+    policy.base_uri    :self
+    policy.form_action :self
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+
+  # Report violations without enforcing the policy initially.
+  # Remove this line once you've verified no legitimate resources are blocked.
+  config.content_security_policy_report_only = true
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,6 +16,11 @@ Rails.application.configure do
     policy.frame_src   :none
     policy.base_uri    :self
     policy.form_action :self
+
+    # Send violation reports to Sentry
+    if ENV["SENTRY_CSP_REPORT_URI"].present?
+      policy.report_uri ENV["SENTRY_CSP_REPORT_URI"]
+    end
   end
 
   # Generate session nonces for permitted importmap and inline scripts.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   end
 
   # Generate session nonces for permitted importmap and inline scripts.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy initially.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,40 @@
+# Rate limiting and request throttling
+class Rack::Attack
+  # Throttle login attempts by IP (20 attempts per 15 minutes)
+  throttle("logins/ip", limit: 20, period: 15.minutes) do |req|
+    req.ip if req.post? && req.path.match?(%r{\A/(login|sessions|api/v1/login|api/v1/google_auth)\z})
+  end
+
+  # Throttle login attempts by email parameter (10 attempts per 15 minutes)
+  throttle("logins/email", limit: 10, period: 15.minutes) do |req|
+    if req.post? && req.path.match?(%r{\A/(login|sessions|api/v1/login)\z})
+      req.params.dig("session", "email")&.downcase&.strip ||
+        req.params.dig("email")&.downcase&.strip
+    end
+  end
+
+  # Throttle password reset requests by IP (5 per 30 minutes)
+  throttle("password_resets/ip", limit: 5, period: 30.minutes) do |req|
+    req.ip if req.post? && req.path == "/password_reset"
+  end
+
+  # Throttle registration attempts by IP (5 per hour)
+  throttle("registrations/ip", limit: 5, period: 1.hour) do |req|
+    req.ip if req.post? && req.path == "/register"
+  end
+
+  # General request throttle by IP (300 requests per 5 minutes)
+  throttle("requests/ip", limit: 300, period: 5.minutes, &:ip)
+
+  # Custom response for throttled requests
+  self.throttled_responder = lambda do |request|
+    match_data = request.env["rack.attack.match_data"] || {}
+
+    headers = {
+      "content-type" => "text/plain",
+      "retry-after" => match_data[:period].to_s
+    }
+
+    [ 429, headers, [ "Too Many Requests" ] ]
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,6 +5,29 @@ if Rails.env.production? && ENV["SENTRY_DSN"].present?
   Sentry.init do |config|
     config.breadcrumbs_logger = [ :active_support_logger ]
     config.dsn = ENV["SENTRY_DSN"]
-    config.traces_sample_rate = 1.0
+
+    # Sample 10% of transactions for performance monitoring
+    config.traces_sample_rate = 0.1
+
+    # Filter sensitive data and noisy errors before sending
+    config.before_send = lambda do |event, hint|
+      exception = hint[:exception]
+
+      # Drop encoding errors from malformed bot/scanner requests
+      if exception.is_a?(Encoding::CompatibilityError) ||
+         exception.is_a?(Encoding::InvalidByteSequenceError) ||
+         exception.is_a?(Encoding::UndefinedConversionError)
+        return nil
+      end
+
+      # Scrub sensitive parameters from request data
+      if event.request&.data.is_a?(Hash)
+        %w[password password_confirmation token secret api_key].each do |key|
+          event.request.data[key] = "[FILTERED]" if event.request.data.key?(key)
+        end
+      end
+
+      event
+    end
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,7 +9,10 @@ if Rails.env.production? && ENV["SENTRY_DSN"].present?
     # Sample 10% of transactions for performance monitoring
     config.traces_sample_rate = 0.1
 
-    # Filter sensitive data and noisy errors before sending
+    # Do not send PII (cookies, user IP, request body) by default
+    config.send_default_pii = false
+
+    # Filter noisy errors before sending
     config.before_send = lambda do |event, hint|
       exception = hint[:exception]
 
@@ -18,13 +21,6 @@ if Rails.env.production? && ENV["SENTRY_DSN"].present?
          exception.is_a?(Encoding::InvalidByteSequenceError) ||
          exception.is_a?(Encoding::UndefinedConversionError)
         return nil
-      end
-
-      # Scrub sensitive parameters from request data
-      if event.request&.data.is_a?(Hash)
-        %w[password password_confirmation token secret api_key].each do |key|
-          event.request.data[key] = "[FILTERED]" if event.request.data.key?(key)
-        end
       end
 
       event

--- a/test/initializers/rack_attack_test.rb
+++ b/test/initializers/rack_attack_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class RackAttackTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_cache = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.enabled = true
+    Rack::Attack.reset!
+  end
+
+  teardown do
+    Rack::Attack.reset!
+    Rack::Attack.cache.store = @original_cache
+  end
+
+  test "throttles excessive login attempts by IP" do
+    21.times do
+      post "/login", params: { session: { email: "test@example.com", password: "wrong" } }
+    end
+
+    assert_equal 429, response.status
+  end
+
+  test "allows normal login attempts" do
+    5.times do
+      post "/login", params: { session: { email: "test@example.com", password: "wrong" } }
+    end
+
+    assert_not_equal 429, response.status
+  end
+
+  test "throttles excessive password reset requests" do
+    6.times do
+      post "/password_reset", params: { password_reset: { email: "test@example.com" } }
+    end
+
+    assert_equal 429, response.status
+  end
+end

--- a/test/middleware/encoding_error_handler_test.rb
+++ b/test/middleware/encoding_error_handler_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class EncodingErrorHandlerTest < ActiveSupport::TestCase
+  def setup
+    @app = ->(env) { raise Encoding::CompatibilityError, "incompatible character encodings: UTF-16LE and UTF-8" }
+    @middleware = EncodingErrorHandler.new(@app)
+  end
+
+  test "returns 400 for Encoding::CompatibilityError" do
+    status, headers, body = @middleware.call({})
+    assert_equal 400, status
+    assert_equal "text/plain", headers["content-type"]
+    assert_equal [ "Bad Request" ], body
+  end
+
+  test "returns 400 for Encoding::InvalidByteSequenceError" do
+    app = ->(env) { raise Encoding::InvalidByteSequenceError }
+    middleware = EncodingErrorHandler.new(app)
+
+    status, _, _ = middleware.call({})
+    assert_equal 400, status
+  end
+
+  test "passes through normal requests" do
+    app = ->(env) { [ 200, { "content-type" => "text/html" }, [ "OK" ] ] }
+    middleware = EncodingErrorHandler.new(app)
+
+    status, _, body = middleware.call({})
+    assert_equal 200, status
+    assert_equal [ "OK" ], body
+  end
+end


### PR DESCRIPTION
## Summary

Security hardening prompted by a Sentry error (RUBY-RAILS-J) from a bot sending malformed UTF-16LE encoded POST requests. Expanded scope to address broader gaps.

- **Encoding middleware** — Catches `Encoding::CompatibilityError` at the Rack level, returns 400 instead of 500. Fixes RUBY-RAILS-J.
- **Rack::Attack rate limiting** — Throttles login (20/15min per IP), password resets (5/30min), registrations (5/hr), and general requests (300/5min).
- **Content Security Policy** — Configured for self, Google Fonts, Stream Chat, ActionCable. Starts in **report-only mode** to catch false positives before enforcing.
- **DNS rebinding protection** — Restricts Host header to `*.crowwoods.com` domains. Allows IP-based health checks.
- **Sentry hardening** — Reduces trace sampling from 100% to 10%, filters encoding errors (bot noise), scrubs passwords/tokens from request data.

## Deployment notes

- **CSP is report-only** — monitor for violations before flipping to enforcing mode
- **Rack::Attack** uses Rails cache store — ensure production cache is running (Solid Cache)
- **Host validation** — if adding new community domains, add them to `config/environments/production.rb`

## Test plan

- [x] 428 tests passing, 1088 assertions
- [x] Rubocop: no offenses
- [x] Brakeman: no security warnings
- [ ] Manual: verify login throttling works in staging
- [ ] Manual: monitor CSP report-only violations in production for 1 week
- [ ] Manual: confirm health check endpoint still works with host validation